### PR TITLE
Fixed nodeport issue on result-service.yml and vote-service.yml

### DIFF
--- a/k8s-specifications/result-service.yaml
+++ b/k8s-specifications/result-service.yaml
@@ -5,11 +5,9 @@ metadata:
     app: result
   name: result
 spec:
-  type: NodePort
   ports:
   - name: "result-service"
     port: 5001
     targetPort: 80
-    nodePort: 31001
   selector:
     app: result

--- a/k8s-specifications/vote-service.yaml
+++ b/k8s-specifications/vote-service.yaml
@@ -5,12 +5,10 @@ metadata:
     app: vote
   name: vote
 spec:
-  type: NodePort
   ports:
   - name: "vote-service"
     port: 5000
     targetPort: 80
-    nodePort: 31002
   selector:
     app: vote
   


### PR DESCRIPTION
Hi @LondheShubham153 sir,

As **we are using port-forwarding on kind k8s cluster** to access the application on browser, **we don't require Nodeport** type in service files, so I have **removed it from result-service.yml and vote-service.yml**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `result` service now automatically assigns a node port, enhancing flexibility in port management.
	- The `vote` service has been updated to a default `ClusterIP` type, optimizing internal communication.

- **Bug Fixes**
	- Corrected YAML formatting for the `result` service, ensuring proper structure and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->