### PR TITLE
all in default

### DIFF
--- a/k8s-specifications/db-deployment.yaml
+++ b/k8s-specifications/db-deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: default
   labels:
     app: db
   name: db

--- a/k8s-specifications/db-service.yaml
+++ b/k8s-specifications/db-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: default
   labels:
     app: db
   name: db

--- a/k8s-specifications/redis-deployment.yaml
+++ b/k8s-specifications/redis-deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: default
   labels:
     app: redis
   name: redis

--- a/k8s-specifications/redis-service.yaml
+++ b/k8s-specifications/redis-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: default
   labels:
     app: redis
   name: redis

--- a/k8s-specifications/result-deployment.yaml
+++ b/k8s-specifications/result-deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: default
   labels:
     app: result
   name: result

--- a/k8s-specifications/result-service.yaml
+++ b/k8s-specifications/result-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: default
   labels:
     app: result
   name: result

--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: default
   labels:
     app: vote
   name: vote

--- a/k8s-specifications/vote-service.yaml
+++ b/k8s-specifications/vote-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: default
   labels:
     app: vote
   name: vote

--- a/k8s-specifications/worker-deployment.yaml
+++ b/k8s-specifications/worker-deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: default
   labels:
     app: worker
   name: worker


### PR DESCRIPTION
ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Added `namespace: default` to Kubernetes deployment and service configurations for:
		- Database
		- Redis
		- Result
		- Vote
		- Worker services

This update ensures all Kubernetes resources are consistently deployed in the default namespace, improving cluster resource management and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->