### PR TITLE
Update vote-deployment.yaml

### DIFF
--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app: vote
   name: vote
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: vote


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Scaled the Vote service deployment from 1 to 2 replicas. Users should see improved responsiveness during peak traffic and greater resilience to pod restarts. This also reduces perceived downtime during rolling updates by maintaining service availability with an additional replica. No interface changes; behavior is otherwise unchanged. No action required by users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->