### PR TITLE
Update nodePort for vote service from 31002 to 31003

### DIFF
--- a/k8s-specifications/vote-service.yaml
+++ b/k8s-specifications/vote-service.yaml
@@ -10,7 +10,7 @@ spec:
   - name: "vote-service"
     port: 5000
     targetPort: 80
-    nodePort: 31002
+    nodePort: 31003
   selector:
     app: vote
   


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the network access port for the vote-service from 31002 to 31003.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->