### PR TITLE
Increase replicas from 1 to 2 in vote deployment

### DIFF
--- a/k8s-specifications/vote-deployment.yaml
+++ b/k8s-specifications/vote-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app: vote
   name: vote
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: vote


### PR DESCRIPTION
Increase replicas from 1 to 2 in vote deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the number of running instances for the vote service, improving availability and resilience during traffic spikes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->